### PR TITLE
Add new type of output if --group parameter(s) are added 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,23 @@
+# This workflow will publish a docker image on tag
+
+name: Upload Docker image on tag
+on:
+    push:
+      tags:
+      - '*'
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build and push docker image
+      run: |
+        IMAGE_ID=ghcr.io/${{ github.repository }}
+        VERSION=${{ github.ref_name }}
+        echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+        docker build -t $IMAGE_ID:$VERSION .
+        docker push $IMAGE_ID:$VERSION

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   s3-files:
-    image: jorop/process-s3-files
+    image: ghcr.io/eoxhub-workspaces/process-s3-files:0.0.7
     entrypoint: sh -c "sleep infinity"
     environment:
     - AWS_ACCESS_KEY_ID=<your access key id>

--- a/process_s3_files.sh
+++ b/process_s3_files.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
+command -v jq >/dev/null || { echo >&2 "jq is required"; exit 1; }
 
 process_group() {
   local group_str="$1"
   local url="$2"
-  local filename="$2"
+  local filename="$3"
   # Extract components from the group config
   local regex id mimetype
   IFS=',' read -r -a parts <<< "$group_str"
@@ -80,6 +81,8 @@ while IFS= read -r FILE; do
         echo "No --group parameter used, will create URLs array."
         OUTPUT=$(echo $OUTPUT | jq -r --arg URL "$URL" '. += [$URL]')
     else
+      # otherwise process the groups from argument
+      # processing means matching regex to filename
         echo "--group parameter(s) used, will create output object."
         for group in "${GROUP_ARGS[@]}"; do
           process_group "$group" "$URL" "$FILE"
@@ -91,6 +94,7 @@ done <<< $FILES
 if [[ ${#GROUP_ARGS[@]} -eq 0 ]]; then
     echo "{\"urls\":$OUTPUT}" > /tmp/out.json
 else
+# write output object to out.json
   json_input="{}"
   for id in "${!GROUP_URLS[@]}"; do
     urls="[${GROUP_URLS[$id]}]"

--- a/process_s3_files.sh
+++ b/process_s3_files.sh
@@ -3,6 +3,30 @@ if [ "$DEBUG" == "true" ]; then
     env
     DEBUGFLAG="--debug"
 fi
+
+GROUP_ARGS=()
+# parse GROUP_ARGS arguments
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --group)
+      if [[ -n "${2-}" ]]; then
+        GROUP_ARGS+=("$2")
+        shift 2
+      else
+        echo "Error: --group requires an argument."
+        exit 1
+      fi
+      ;;
+    --group=*)
+      GROUP_ARGS+=("${1#*=}")
+      shift
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
 # Get last modified file in $BUCKET at $BPATH
 FILES=$(aws $DEBUGFLAG s3 ls --region $AWS_REGION --endpoint-url $AWS_S3_ENDPOINT s3://$BUCKET/$BPATH/ | sort | tail -n $NUM_FILES | awk '{ print $4 }')
 URL_LIST="[]"
@@ -13,11 +37,17 @@ while IFS= read -r FILE; do
     echo Permissions set to $ACL
     # add to url array
     URL=$AWS_S3_ENDPOINT/$BUCKET/$BPATH/$FILE
-    URL_LIST=$(echo $URL_LIST | jq -r --arg URL "$URL" '. += [$URL]')
+    # If no group provided, create URL array (legacy mode)
+    if [[ ${#GROUP_ARGS[@]} -eq 0 ]]; then
+        echo "No --group parameter supplied, will create URLs array."
+        URL_LIST=$(echo $URL_LIST | jq -r --arg URL "$URL" '. += [$URL]')
+    fi
 done <<< $FILES
 
 # write file url to out.json
-echo "{\"urls\":$URL_LIST}" > /tmp/out.json
+if [[ ${#GROUP_ARGS[@]} -eq 0 ]]; then
+    echo "{\"urls\":$URL_LIST}" > /tmp/out.json
+fi
 # store json in bucket
 if [ "$PUBLISH_JSON" == "true" ]; then
     declare -n PUBLISH_JSON_FILENAME_VALUE=${PUBLISH_JSON_FILENAME_ENV_VAR}


### PR DESCRIPTION
Running command without any parameters keeps the old behavior.
Adding `--group` parameter(s) in format `regex=regex1,id=id1,mimetype=mimetype1`
does matching on the filename for regex and puts it into correct output object.

`/process_s3_files.sh --group "regex=harshness.*,id=output_1,mimetype=image/tiff" --group "regex=*other_process.*,id=output_2,mimetype=image/tiff"`

yields:

```json
{
  "output_1":{
    "urls":[
      "url1",
      "url2"
    ],
    "mimetype":"image/tiff"
  },
  "output_2":{
    "urls":[
      "url3"
    ],
    "mimetype":"image/tiff"
  }
}
```
`/process_s3_files.sh would yield:
```json
{
  "urls":[
    "url1"
  ]
}
```
